### PR TITLE
Add libcurl and windows instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ if(Boost_FOUND)
   add_executable(boosttest src/boosttest.cpp)
 endif()
 
-find_package(CURL CONFIG REQUIRED)
+find_package(CURL REQUIRED)
+include_directories(${CURL_INCLUDE_DIRS})
 
 add_executable(hello src/helloworld.cpp)
 target_link_libraries(hello PRIVATE CURL::libcurl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,7 @@ if(Boost_FOUND)
   add_executable(boosttest src/boosttest.cpp)
 endif()
 
+find_package(CURL CONFIG REQUIRED)
 
 add_executable(hello src/helloworld.cpp)
+target_link_libraries(hello PRIVATE CURL::libcurl)

--- a/README.md
+++ b/README.md
@@ -6,27 +6,46 @@ We've noticed that more often than not, we've had to spend a significant portion
 We've created a (rather ad-hoc) Cmake project to help candidates determine if their laptops were setup to write C++, so interviews can be about evaluating the candidate, and not the way their environment is setup.
 
 # Getting ready
-First, clone this repository to your computer (creating a fork of the repository is not necessary). Next, ensure that you have `cmake` and a C++ compiler installed.
+First, clone this repository to your computer (creating a fork of the repository is not necessary). Next, ensure that you have `cmake`, a C++ compiler and `libcurl` installed.
 
+## Linux or macOS
 - If you're using Debian or Ubuntu, you likely want to run `sudo apt-get install cmake build-essential`.
-- If you're using macOS with HomeBrew installed, you might want to run `brew install cmake`.
-- Otherwise, you can find installation instructions for `cmake` [here](https://cmake.org/install/).
+- If you're using macOS with HomeBrew installed, you might want to run `brew install cmake curl`.
 
 If you can run these commands, your development environment is probably ready for Stripe's C++ interview questions:
 
 ```
-# On all platforms:
 $ cmake --version
 $ git clone [the project's URL]
 $ cd [into the project]
 $ mkdir build
 $ cd build
 $ cmake ..
-
-# On Linux or macOS:
 $ make
 $ ./hello
-
-# On Windows with Visual Studio installed:
-# open cpp-interview-prep.sln, build and run
 ```
+
+## Windows (Visual Studio)
+- Make sure you have the **C++ CMake tools for Windows** installed. These should automatically be there if you selected C++ as a language when installing Visual Studio. There are more instructions on installing `cmake` in Visual Studio [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019#installation).
+- Install `libcurl` using `vcpkg`.
+    ```
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install --triplet x64-windows curl[tool]
+    ```
+- Optionally, you can also install `boost` via `vcpkg` if you would like to use it. (This will take a while, 30mins or more!) 
+    ```
+    vcpkg install --triplet x64-windows boost
+    ```
+- Setup the project in Visual Studio
+    - Make sure you open the folder with this repository via **File > Open > Folder** menu item and Visual Studio should automatically detect and run `cmake`.
+    - The output window should not show any errors once `cmake` completes.
+    - There are more details on using `cmake` and Visual Studio [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019#ide-integration).  
+
+- You should now be able to right click on `helloworld.cpp` in Solution Explorer and be able to `compile` and `debug`(run) the code
+
+## Other platforms or if you want to debug
+- You can find installation instructions for `cmake` [here](https://cmake.org/install/).
+- You can find installation instructions for `libcurl` [here](https://curl.haxx.se/docs/install.html).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Thanks for interviewing at Stripe. To make sure that we can use our time best in
 
 We've noticed that more often than not, we've had to spend a significant portion of the interview helping candidates setup a Cmake-based C++ environment on their personal laptops.
 
-We've created a (rather ad-hoc) Cmake project to help candidates determine if their laptops were setup to write C++, so interviews can be about evaluating the candidate, and not the way their environment is setup.
+We've created a (rather ad-hoc) CMake project to help candidates determine if their laptops were setup to write C++, so interviews can be about evaluating the candidate, and not the way their environment is setup.
 
 # Getting ready
 First, clone this repository to your computer (creating a fork of the repository is not necessary). Next, ensure that you have `cmake`, a C++ compiler and `libcurl` installed.
@@ -26,26 +26,26 @@ $ ./hello
 ```
 
 ## Windows (Visual Studio)
-- Make sure you have the **C++ CMake tools for Windows** installed. These should automatically be there if you selected C++ as a language when installing Visual Studio. There are more instructions on installing `cmake` in Visual Studio [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019#installation).
-- Install `libcurl` using `vcpkg`.
+- Make sure you have the **C++ CMake tools for Windows** installed. These should automatically be there if you selected C++ as a language when installing Visual Studio. There are more instructions on installing `CMake` in Visual Studio [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019#installation).
+- Install `libcurl` using `vcpkg`. Open Windows PowerShell and run the following
     ```
     git clone https://github.com/Microsoft/vcpkg.git
     cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    vcpkg install --triplet x64-windows curl[tool]
+    .\bootstrap-vcpkg.bat
+    .\vcpkg.exe integrate install
+    .\vcpkg.exe install --triplet x64-windows curl[tool]
     ```
 - Optionally, you can also install `boost` via `vcpkg` if you would like to use it. (This will take a while, 30mins or more!) 
     ```
     vcpkg install --triplet x64-windows boost
     ```
 - Setup the project in Visual Studio
-    - Make sure you open the folder with this repository via **File > Open > Folder** menu item and Visual Studio should automatically detect and run `cmake`.
-    - The output window should not show any errors once `cmake` completes.
-    - There are more details on using `cmake` and Visual Studio [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019#ide-integration).  
+    - Make sure you open the folder with this repository via **File > Open > Folder** menu item and Visual Studio should automatically detect and run `cmake.exe`.
+    - The output window should not show any errors once CMake completes.
+    - There are more details on using CMake with Visual Studio [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019#ide-integration).  
 
 - You should now be able to right click on `helloworld.cpp` in Solution Explorer and be able to `compile` and `debug`(run) the code
 
 ## Other platforms or if you want to debug
-- You can find installation instructions for `cmake` [here](https://cmake.org/install/).
+- You can find installation instructions for `CMake` [here](https://cmake.org/install/).
 - You can find installation instructions for `libcurl` [here](https://curl.haxx.se/docs/install.html).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Interview preparation
 Thanks for interviewing at Stripe. To make sure that we can use our time best in the interview, we'd like to have you do some setup in advance.
 
-We've noticed that more often than not, we've had to spend a significant portion of the interview helping candidates setup a Cmake-based C++ environment on their personal laptops.
+We've noticed that more often than not, we've had to spend a significant portion of the interview helping candidates setup a CMake-based C++ environment on their personal laptops.
 
 We've created a (rather ad-hoc) CMake project to help candidates determine if their laptops were setup to write C++, so interviews can be about evaluating the candidate, and not the way their environment is setup.
 
@@ -14,9 +14,9 @@ First, clone this repository to your computer (creating a fork of the repository
 
 If you can run these commands, your development environment is probably ready for Stripe's C++ interview questions:
 
-```
+```powershell
 $ cmake --version
-$ git clone [the project's URL]
+$ git clone [project URL]
 $ cd [into the project]
 $ mkdir build
 $ cd build
@@ -35,13 +35,13 @@ $ ./hello
     .\vcpkg.exe integrate install
     .\vcpkg.exe install --triplet x64-windows curl[tool]
     ```
-- Optionally, you can also install `boost` via `vcpkg` if you would like to use it. (This will take a while, 30mins or more!) 
+- Optionally, you can also install [boost](https://www.boost.org/) via `vcpkg` if you would like to use it. (This will take a while, 30mins or more!) 
     ```
     vcpkg install --triplet x64-windows boost
     ```
 - Setup the project in Visual Studio
     - Make sure you open the folder with this repository via **File > Open > Folder** menu item and Visual Studio should automatically detect and run `cmake.exe`.
-    - Double click on `CmakeLists.txt` and that should trigger a build. The output window should not show any errors once CMake completes.
+    - Double click on `CMakeLists.txt` and that should trigger a build. The output window should not show any errors once CMake completes.
     - There are more details on using CMake with Visual Studio [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019#ide-integration).  
 
 - You should now be able to right click on `helloworld.cpp` in Solution Explorer and be able to `compile` and `debug`(run) the code

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ ./hello
     ```
 - Setup the project in Visual Studio
     - Make sure you open the folder with this repository via **File > Open > Folder** menu item and Visual Studio should automatically detect and run `cmake.exe`.
-    - The output window should not show any errors once CMake completes.
+    - Double click on `CmakeLists.txt` and that should trigger a build. The output window should not show any errors once CMake completes.
     - There are more details on using CMake with Visual Studio [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019#ide-integration).  
 
 - You should now be able to right click on `helloworld.cpp` in Solution Explorer and be able to `compile` and `debug`(run) the code

--- a/src/helloworld.cpp
+++ b/src/helloworld.cpp
@@ -2,10 +2,25 @@
 #include<curl/curl.h>
  
 int main(int argc, char *argv[]) {
-  CURL* curl;
-  curl = curl_easy_init();
-  curl_easy_cleanup(curl);
 
   std::cout << "Hello World!" << std::endl;
+
+  CURL* curl;
+  CURLcode res;
+
+  curl = curl_easy_init();
+
+  const char *data = "foo=bar"; 
+  curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
+  curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+
+  res = curl_easy_perform(curl);
+  if(res == CURLE_OK) {
+    long response_code;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+    std::cout << "Got response code: " << response_code << std::endl;
+  }
+
+  curl_easy_cleanup(curl);
   return 0;
 }

--- a/src/helloworld.cpp
+++ b/src/helloworld.cpp
@@ -1,6 +1,11 @@
 #include<iostream>
+#include<curl/curl.h>
  
 int main(int argc, char *argv[]) {
+  CURL* curl;
+  curl = curl_easy_init();
+  curl_easy_cleanup(curl);
+
   std::cout << "Hello World!" << std::endl;
   return 0;
 }


### PR DESCRIPTION
- Make the build fail if candidate doesn't have `libcurl`.
- Add instructions for how to install, mainly Windows + Visual Studio since the instructions are not easy to find. 