### PR TITLE
Added instructions to install libraries. Also, help cmake find libcurl.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,4 +20,4 @@ find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIRS})
 
 add_executable(hello src/helloworld.cpp)
-target_link_libraries(hello PRIVATE CURL::libcurl)
+target_link_libraries(hello PRIVATE ${CURL_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ We've created a (rather ad-hoc) CMake project to help candidates determine if th
 First, clone this repository to your computer (creating a fork of the repository is not necessary). Next, ensure that you have `cmake`, a C++ compiler and `libcurl` installed.
 
 ## Linux or macOS
-- If you're using Debian or Ubuntu, you likely want to run `sudo apt-get install cmake build-essential`.
+- If you're using Debian or Ubuntu, you likely want to run
+```
+# One command, spread over several lines...
+sudo apt-get install \
+  cmake build-essential \
+  libboost-all-dev \
+  libcurl4-openssl-dev libcurlpp-dev
+```
 - If you're using macOS with HomeBrew installed, you might want to run `brew install cmake curl`.
 
 If you can run these commands, your development environment is probably ready for Stripe's C++ interview questions:


### PR DESCRIPTION
Without the cmake change, cmake exhibited these symptoms:

```
$ cmake ..
-- Boost version: 1.65.1
-- Configuring done
CMake Error at CMakeLists.txt:22 (add_executable):
  Target "hello" links to target "CURL::libcurl" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?


-- Generating done
-- Build files have been written to: /mnt/c/Users/allyourcode/src/stripe-cc/build
```

cmake would exhibit other symptoms when the needed libraries (boost and libcurl) were not installed. Installation instructions (for Debian/Ubuntu users) for those libraries are also in this PR.